### PR TITLE
link MapView and ListVeiw to homePage

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -1,0 +1,11 @@
+import {useState} from 'react';
+
+const ListView = (props) => {
+  const [map, setMap] = useState(false);
+
+  return (
+    <div>ListView Here</div>
+  )
+}
+
+export default ListView;

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -1,0 +1,11 @@
+import {useState} from 'react';
+
+const MapView = (props) => {
+  const [list, setList] = useState(false);
+
+  return (
+    <div> Maps View here</div>
+  )
+}
+
+export default MapView;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,22 @@
-function HomePage() {
-  return <div>Welcome back to Next.js!</div>
+import ListView from '../components/ListView.js';
+import MapView from '../components/MapView.js';
+import { useState } from 'react';
+
+const HomePage = (props) => {
+  const [view, setView] = useState('list');
+
+  const ChangeView = (input) => {
+    setView(input);
+  }
+
+  return (
+    <div>
+      Welcome back to Next.js!
+      {view === 'list' ? <p onClick={() => ChangeView('map')}>Show Map</p> : <p onClick={() => ChangeView('list')}>Show List</p>}
+      {view === 'map' && <MapView />}
+      {view === 'list' && <ListView />}
+    </div>
+  )
 }
 
 export default HomePage;


### PR DESCRIPTION
A reference to a related issue in your repository.

A description of the changes proposed in the pull request.


## Story / Task

Here goes the link and info of the task/story.  
Example:

see [Project-Task|Story](link())


## What this PR does?

This PR just linked MapView and ListView to the homepage.  
The app by default will show the listView, but click on the show Map button the app will switch to List view 


### Before 

NA

### After

The app by default will show the listView, but click on the show Map button the app will switch to List view 
(Add screenshot / gif if necessary)

### How to test / reproduce

- Here goes the steps to do the test.
- Other step.

### TODOs
- [ ] Tests
- [ ] Documentation

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Mentions

At last, @mention team members you want involve, if necessary.
Add them as reviewers

and a "Thanks!" would be great! 
