### PR TITLE
add routing and layout for donations and claims history

### DIFF
--- a/components/NaviBar.js
+++ b/components/NaviBar.js
@@ -10,8 +10,8 @@ const NaviBar = (props) => {
     <div>
       <Nav defaultActiveKey="/" className="flex-column">
         <Nav.Link href="/">Home</Nav.Link>
-        <Nav.Link href="/donations">My Donations</Nav.Link>
-        <Nav.Link href="/Claims">My Claims</Nav.Link>
+        <Nav.Link href="/history/donations">My Donations</Nav.Link>
+        <Nav.Link href="/history/claims">My Claims</Nav.Link>
         <Nav.Link href="/posts">Post an Item</Nav.Link>
         <Nav.Link eventKey="disabled" disabled>
           LogOut

--- a/pages/history/claims.js
+++ b/pages/history/claims.js
@@ -1,0 +1,31 @@
+import { Button, InputGroup, FormControl } from 'react-bootstrap';
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { FaSearch} from "react-icons/fa";
+import {useState} from 'react';
+
+const Claims = (props) => {
+  let [searching, setSearching] = useState('');
+
+  const handleSearch = (e) =>{
+    setSearching(e.target.value)
+  }
+
+  return (
+    <>
+      <div>My Claims</div>
+      <InputGroup>
+        <FormControl
+          placeholder="Search my claims..."
+          value={searching}
+          onChange={handleSearch}
+        />
+        <Button variant="outline-secondary">
+          <FaSearch />
+        </Button>
+      </InputGroup>
+      <div>List of Claims Here</div>
+    </>
+  )
+}
+
+export default Claims;

--- a/pages/history/donations.js
+++ b/pages/history/donations.js
@@ -1,0 +1,31 @@
+import { Button, InputGroup, FormControl } from 'react-bootstrap';
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { FaSearch} from "react-icons/fa";
+import {useState} from 'react';
+
+const Donations = (props) => {
+  let [searching, setSearching] = useState('');
+
+  const handleSearch = (e) =>{
+    setSearching(e.target.value)
+  }
+
+  return (
+    <>
+      <div>My Donations</div>
+      <InputGroup>
+        <FormControl
+          placeholder="Search my donations..."
+          value={searching}
+          onChange={handleSearch}
+        />
+        <Button variant="outline-secondary">
+          <FaSearch />
+        </Button>
+      </InputGroup>
+      <div>List of Donations Here</div>
+    </>
+  )
+}
+
+export default Donations;


### PR DESCRIPTION
This PR updates routing to the claims/donations history page, and add minimal layout to the two pages.


## Story / Task

Here goes the link and info of the task/story.  
Example:

see [Set up history pages](https://trello.com/c/f934UVg0)


## What this PR does?

Updated routing in the NavBar. Add layout to My Claims and My Donations pages.


### Before 

Clicking on the My Claims and My Donations link in the NavBar will lead to 404 page not found

### After
After clicking the My Donations and My Claims button, claims/donations component are rendered.
![gif_showing_changes](http://g.recordit.co/tBe4tHZZaN.gif)

### How to test / reproduce

- No test yet

### TODOs
- [ ] Tests
- [ ] Documentation

### Related PRs
- NA

## Mentions

@ajpsyk @DevonL1010 @vinhle000 @davidhannn @merosenlund @stevenxm-chen @Doomslair 

Thank you!
