### PR TITLE
Maps info window behavior

### DIFF
--- a/components/MapView.js
+++ b/components/MapView.js
@@ -21,21 +21,13 @@ const items = [
 
 function MapView(props) {
 
-  // const {isLoaded, loadError} = useLoadScript({
-  //   googleMapsApiKey:process.env.mapAPI
-  // })
-
-  // if ( loadError) return 'Error Loading Maps';
-  // if ( !isLoaded) return 'Loading Maps';
-
   const [selected, setSelected] = useState(null)
-
 
 
   const position = { lat: 47.61483, lng: -122.3146 }
 
 
-  const containerStyle = {
+  const mapContainerStyle = {
     width: '400px',
     height: '400px'
   };
@@ -59,13 +51,18 @@ function MapView(props) {
   return (
     <LoadScript googleMapsApiKey={process.env.mapAPI} >
       <GoogleMap
-        mapContainerStyle={containerStyle}
+        // className='mapContainer'
+        mapContainerStyle={mapContainerStyle}
         center={center}
         zoom={13}
+        onClick={(e) => {
+          setSelected(null)}}
+
         options={{
           disableDefaultUI: true,
           zoomControl: true,
         }}
+
       >
         { /* Child components, such as markers, info windows, etc. */ }
         {items.map( (item, index) => {
@@ -82,15 +79,19 @@ function MapView(props) {
 
         {selected ? (
           <InfoWindow
-            options={{pixelOffset: new window.google.maps.Size(0, -45) }}
-            position={{lat: selected.coordinates.lat, lng: selected.coordinates.lng}}
-            onCloseClick={() => {
-              setSelected(null)
+            options={{
+              pixelOffset: new window.google.maps.Size(0, -45),
             }}
+
+            position={{lat: selected.coordinates.lat, lng: selected.coordinates.lng}}
+            // onCloseClick={() => {
+            //   setSelected(null) //OPEN LIST VIEW ITEM
+            // }}
           >
 
             <div style={infoWindowStyle}>
               <img style={{width: '100%', height: '100'}} src={selected.img_url} />
+              <div style={{'font-size': 'x-small'}}>{selected.name} </div>
             </div>
 
           </InfoWindow>

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -1,31 +1,30 @@
 import React, {useState} from 'react'
 import { GoogleMap, LoadScript, Marker, InfoWindow} from '@react-google-maps/api';
-
+import {Card, Container, Row, Col, Modal} from 'react-bootstrap';
+import ItemView from './ItemView.js'
 
 //TODO: Remove after real/formatted data is provided
 //SampleTest data for showing markers
 const items = [
   {
     name: 'Space Needle',
-    img_url: 'https://cdn.pixabay.com/photo/2016/11/23/01/18/red-panda-1851661_1280.jpg',
+    img: 'https://cdn.pixabay.com/photo/2016/11/23/01/18/red-panda-1851661_1280.jpg',
     coordinates: { lat: 47.6205, lng: -122.3493 },
   },
   {
     name: "Cal Anderson Park",
-    img_url: 'https://cdn.pixabay.com/photo/2016/11/23/01/15/red-panda-1851650_1280.jpg',
+    img: 'https://cdn.pixabay.com/photo/2016/11/23/01/15/red-panda-1851650_1280.jpg',
     coordinates: { lat: 47.6173, lng: -122.3195 },
   },
 ]
 
 
-
 function MapView(props) {
+  const [selectedMarker, setSelectedMarker] = useState(null);
+  const [isSelected, setIsSelected] = useState(false);
 
-  const [selected, setSelected] = useState(null)
-
-
-  const position = { lat: 47.61483, lng: -122.3146 }
-
+  const viewItem = () => setIsSelected(true);
+  const closeItem = () => setIsSelected(false);
 
   const mapContainerStyle = {
     width: '400px',
@@ -38,33 +37,31 @@ function MapView(props) {
     height: '10vh',
   }
 
-  const center = {
+  const center = { //TODO: to be set as User Searched center
     lat: 47.6253,
     lng: -122.3222
   };
-
 
   const onLoad = marker => {
     console.log('marker: ', marker)
   }
 
   return (
+    <>
     <LoadScript googleMapsApiKey={process.env.mapAPI} >
       <GoogleMap
-        // className='mapContainer'
         mapContainerStyle={mapContainerStyle}
         center={center}
         zoom={13}
-        onClick={(e) => {
-          setSelected(null)}}
-
         options={{
           disableDefaultUI: true,
           zoomControl: true,
         }}
-
+        onClick={(e) => {
+          setSelectedMarker(null)}}
       >
         { /* Child components, such as markers, info windows, etc. */ }
+
         {items.map( (item, index) => {
           return (
             <Marker
@@ -72,26 +69,21 @@ function MapView(props) {
               onLoad={onLoad}
               position={item.coordinates}
               onClick={(e)=> {
-                setSelected(item)}}
+                setSelectedMarker(item)}}
             />
           )}
         )}
 
-        {selected ? (
+        {selectedMarker ? (
           <InfoWindow
-            options={{
-              pixelOffset: new window.google.maps.Size(0, -45),
-            }}
+            options={{pixelOffset: new window.google.maps.Size(0, -45)}}
+            position={{lat: selectedMarker.coordinates.lat, lng: selectedMarker.coordinates.lng}}
 
-            position={{lat: selected.coordinates.lat, lng: selected.coordinates.lng}}
-            // onCloseClick={() => {
-            //   setSelected(null) //OPEN LIST VIEW ITEM
-            // }}
           >
 
-            <div style={infoWindowStyle}>
-              <img style={{width: '100%', height: '100'}} src={selected.img_url} />
-              <div style={{'font-size': 'x-small'}}>{selected.name} </div>
+            <div style={infoWindowStyle} onClick={() => setIsSelected(true)} >
+              <img style={{width: '100%', height: '100'}} src={selectedMarker.img} />
+              <div style={{'font-size': 'x-small'}}>{selectedMarker.name} </div>
             </div>
 
           </InfoWindow>
@@ -99,6 +91,12 @@ function MapView(props) {
 
       </GoogleMap>
    </LoadScript>
+
+   <Modal centered show={isSelected} size='md' onHide={() => setIsSelected(false)}>
+     <Modal.Header closeButton></Modal.Header>
+     <ItemView />
+   </Modal>
+   </>
   )
 }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { Button, Offcanvas, Container, Col, Row } from 'react-bootstrap';
 import NaviBar from '../components/NaviBar.js';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/signup.css';
+import '../styles/mapView.css'
 
 function MyApp({ Component, pageProps }) {
 

--- a/styles/mapView.css
+++ b/styles/mapView.css
@@ -1,0 +1,3 @@
+.gm-ui-hover-effect{
+  display: none !important;
+}


### PR DESCRIPTION


## Story / Task
[
](https://trello.com/c/NCP6Lbi7/48-selecting-the-infowindow-will-take-user-to-the-donation-item-view-page)

## What this PR does?
-Removed the 'X' button form the infoWindow
-InfoWindow is now closed by either clicking on the map, or selecting another Marker.
-Clicking on the infoWindow will bring up the Item View modal.


### Current Behavior
![Maps_InfoWindow_Behavior](https://user-images.githubusercontent.com/26887964/145856241-513c33fe-fdd9-415a-825c-0f89811bb26b.gif)


### TODOs
- [ ] Tests
- [ ] Documentation

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Mentions

@ajpsyk @Doomslair @davidhannn
@stevenxm-chen @merosenlund
 @yxxy666 @DevonL1010 Please review whenever you have some time, Thanks!
