### PR TITLE
Added endpoints for delist and unclaim an item

### DIFF
--- a/backend/controllers/history.js
+++ b/backend/controllers/history.js
@@ -80,9 +80,30 @@ const postReceiptHis = async (req, res) => {
   });
 };
 
+const delist = async (req, res) => {
+  const itemId = req.query.itemId;
+  await Item.destroy({
+    where: {
+      id: itemId
+    }
+  })
+  .then(data => {
+    res.status(204).json(`Succesfully deleted item ${itemId}`)
+  })
+  .catch(err => {
+    res.status(500).json('Error delist the item', err)
+  })
+}
+
+const unclaim = () => {
+
+}
+
 module.exports = {
   getDonateHis,
   getClaimHis,
   getReceiptHis,
-  postReceiptHis
+  postReceiptHis,
+  unclaim,
+  delist
 };

--- a/backend/controllers/history.js
+++ b/backend/controllers/history.js
@@ -95,8 +95,30 @@ const delist = async (req, res) => {
   })
 }
 
-const unclaim = () => {
+const unclaim = async (req, res) => {
+  const itemId = req.query.itemId;
 
+  await Claim.destroy({
+    where: {
+      itemId: itemId
+    }
+  })
+  .then(data => {
+    Item.update({
+      status: 'unclaimed',
+      claimed: 'f'
+    }, {
+      where: {
+        id: itemId
+      }
+    })
+  })
+  .then(data => {
+    res.json(data).sendStatus(200)
+  })
+  .catch(err => {
+    res.json(err).sendStatus(500)
+  })
 }
 
 module.exports = {

--- a/backend/routes/historyRoutes.js
+++ b/backend/routes/historyRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { getDonateHis, getClaimHis, getReceiptHis, postReceiptHis } = require('../controllers/history.js');
+const { getDonateHis, getClaimHis, getReceiptHis, postReceiptHis, delist, unclaim } = require('../controllers/history.js');
 
 // router.get('/history/donations', getDonateHis);
 
@@ -10,5 +10,8 @@ router.get('/claims', getClaimHis);
 // router.get('/claims', getClaimHis);
 router.get('/receipts', getReceiptHis)
 router.post('/receipts', postReceiptHis);
+
+router.delete('/donations', delist);
+router.delete('/claims', unclaim);
 
 module.exports = router;

--- a/backend/routes/historyRoutes.js
+++ b/backend/routes/historyRoutes.js
@@ -12,6 +12,6 @@ router.get('/receipts', getReceiptHis)
 router.post('/receipts', postReceiptHis);
 
 router.delete('/donations', delist);
-router.delete('/claims', unclaim);
+router.put('/claims', unclaim);
 
 module.exports = router;


### PR DESCRIPTION
## Story / Task

Here goes the link and info of the task/story.  
Example:

see [History](https://trello.com/c/7tS7YofX)


## What this PR does?

Added endpoints for delist or unclaim an item.
Delist: DELETE request to `history/donations` with `itemId` in parameter. Will delete the record for that item in the items table.
Unclaim: PUT request to `history/claims` with `itemId` in parameter. Will delete the record for that item in the claims table, and change status to 'unclaimed' in the items table


### How to test / reproduce

- Can test using Postman

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
history | [link](https://github.com/Ideal-Media-Solutions-LLC/chadslist/pull/75)

@Doomslair @ajpsyk @stevenxm-chen @vinhle000 @DevonL1010 @merosenlund @davidhannn 

Thank you!
