### PR TITLE
Connect unclaim/delist button to server

### DIFF
--- a/components/HistoryList.js
+++ b/components/HistoryList.js
@@ -22,7 +22,7 @@ const getHistory = (userId, histType) => {
   });
 }
 
-const HistListEntry = ( {item, histType} ) => {
+const HistListEntry = ( {item, histType, toggleModal} ) => {
   const [showModal, setShowModal] = useState(false);
   const [price, setPrice] = useState('');
   const {user} = useContext(AuthContext);
@@ -37,6 +37,7 @@ const HistListEntry = ( {item, histType} ) => {
 
   const handleClick = () => {
     setShowModal(!showModal);
+    toggleModal();
   }
 
   const updatePrice = (e) => {
@@ -59,7 +60,7 @@ const HistListEntry = ( {item, histType} ) => {
         <div>{moment(item.createdAt).format("MM/DD/YYYY")}</div>
         {(user && user.accType === 'charity') && <form onSubmit={updatePrice} ><input onChange={(e) => setPrice(e.target.value)} type='number' placeholder=' Edit Value'/> <input type='submit' value='update'/></form>}
       </div>
-      {!showModal ? null : <ItemModal data={item} onHistClick={handleClick.bind(this)} page='history' revoke={revokeOption}/>}
+      {!showModal ? null : <ItemModal data={item} onHistClick={handleClick.bind(this)} page='history' revoke={revokeOption} toggleModal={toggleModal}/>}
     </div>
   )
 }
@@ -67,10 +68,15 @@ const HistListEntry = ( {item, histType} ) => {
 const HistoryList = ( { histType } ) => {
   // need to fix the userId later;
   const {user} = useContext(AuthContext);
-  const userId = 8
+  const userId = 50;
   const [allHistItems, setAllHistItems] = useState(null);
   const [displayedItems, setDisplayedItems] = useState(null);
   const [searchTerm, setSearchTerm] = useState(null);
+  const [modalView, setModalView] = useState(false);
+
+  const toggleModal = () => {
+    setModalView(!modalView)
+  }
 
   const handleSearch = (e) =>{
     let searchStr = e.target.value;
@@ -91,12 +97,12 @@ const HistoryList = ( { histType } ) => {
     .catch(err => {
       console.log(`Error getting user history ${histType}`, err);
     })
-  }, [userId, histType])
+  }, [userId, histType, modalView])
 
   useEffect(() => {
     if (displayedItems !== null) {
       if (searchTerm) {
-        setDisplayedItems(displayedItems.filter((item) => {
+        setDisplayedItems(allHistItems.filter((item) => {
           return item.name.toLowerCase().includes(searchTerm.toLowerCase().trim());
         }))
       } else {
@@ -105,7 +111,7 @@ const HistoryList = ( { histType } ) => {
     }
   }, [userId, searchTerm])
 
-  // console.log(searchTerm);
+  console.log('have modal open?', modalView);
   // console.log(displayedItems);
   return (
     <>
@@ -123,7 +129,7 @@ const HistoryList = ( { histType } ) => {
         {
           displayedItems &&
           displayedItems.map(item => {
-            return <HistListEntry item={item} key={item.id} histType={histType}/>
+            return <HistListEntry item={item} key={item.id} histType={histType} toggleModal={toggleModal.bind(this)}/>
           })
         }
       </div>

--- a/components/HistoryList.js
+++ b/components/HistoryList.js
@@ -57,7 +57,7 @@ const HistListEntry = ( {item, histType} ) => {
         <div onClick={handleClick}>{item.name}</div>
         <div>{(item.status).charAt(0).toUpperCase() + (item.status).slice(1)}</div>
         <div>{moment(item.createdAt).format("MM/DD/YYYY")}</div>
-        {(user.accType === 'charity') && <form onSubmit={updatePrice} ><input onChange={(e) => setPrice(e.target.value)} type='number' placeholder=' Edit Value'/> <input type='submit' value='update'/></form>}
+        {(user && user.accType === 'charity') && <form onSubmit={updatePrice} ><input onChange={(e) => setPrice(e.target.value)} type='number' placeholder=' Edit Value'/> <input type='submit' value='update'/></form>}
       </div>
       {!showModal ? null : <ItemModal data={item} onHistClick={handleClick.bind(this)} page='history' revoke={revokeOption}/>}
     </div>
@@ -67,7 +67,7 @@ const HistListEntry = ( {item, histType} ) => {
 const HistoryList = ( { histType } ) => {
   // need to fix the userId later;
   const {user} = useContext(AuthContext);
-  const userId = 40
+  const userId = 1
   const [allHistItems, setAllHistItems] = useState(null);
   const [displayedItems, setDisplayedItems] = useState(null);
   const [searchTerm, setSearchTerm] = useState(null);

--- a/components/HistoryList.js
+++ b/components/HistoryList.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useCallback } from 'react';
 import AuthContext from '../context/auth/AuthContext';
 import { Card, Container, Row, Col, Modal, Button, CloseButton, InputGroup, FormControl } from 'react-bootstrap';
 import axios from 'axios';
@@ -67,7 +67,7 @@ const HistListEntry = ( {item, histType} ) => {
 const HistoryList = ( { histType } ) => {
   // need to fix the userId later;
   const {user} = useContext(AuthContext);
-  const userId = 1
+  const userId = 8
   const [allHistItems, setAllHistItems] = useState(null);
   const [displayedItems, setDisplayedItems] = useState(null);
   const [searchTerm, setSearchTerm] = useState(null);

--- a/components/HistoryList.js
+++ b/components/HistoryList.js
@@ -90,7 +90,7 @@ const HistoryList = ( { histType } ) => {
   useEffect(() => {
     getHistory(userId, histType)
     .then(res => {
-      console.log('what did server return', res.data);
+      // console.log('what did server return', res.data);
       setAllHistItems(res.data);
       setDisplayedItems(res.data);
     })
@@ -111,7 +111,7 @@ const HistoryList = ( { histType } ) => {
     }
   }, [userId, searchTerm])
 
-  console.log('have modal open?', modalView);
+  // console.log('have modal open?', modalView);
   // console.log(displayedItems);
   return (
     <>

--- a/components/ItemModal.js
+++ b/components/ItemModal.js
@@ -2,11 +2,11 @@ import { Card, Container, Row, Col, Modal } from 'react-bootstrap';
 import { useState } from 'react'
 import ItemView from './ItemView';
 
-const ItemModal = ({ data, onHistClick, page, revoke }) => {
+const ItemModal = ({ data, onHistClick, page, revoke, toggleModal }) => {
   const [show, setShow] = useState(true);
 
   return (
-    <Modal centered show={show} size='md' onHide={() => {setShow(!show); if (page === 'history') {onHistClick()}}}>
+    <Modal centered show={show} size='md' onHide={() => {setShow(!show); toggleModal(); if (page === 'history') {onHistClick()}}}>
         <Modal.Header closeButton></Modal.Header>
         <ItemView data={data} currentPage={page} revoke={revoke}/>
     </Modal>

--- a/components/ItemView.js
+++ b/components/ItemView.js
@@ -17,16 +17,27 @@ const ItemView = ({ data, currentPage, revoke }) => {
   const closeMessage = () => setMessage(false);
   const [isClaim, setIsClaim] = useState(false);
   const [histClaim, setHistClaim] = useState(true);
+  const [histList, setHistList] = useState(true);
   const [page, setPage] = useState(currentPage);
 
   const handleHistClaim = (e) => {
     axios.put(`http://localhost:3001/history/claims?itemId=${id}`)
         .then(res => {
-          setHistClaim(false);
+          setHistClaim(false)
         })
         .catch(err => {
           console.log('unclaim err', err)
         })
+  }
+
+  const handleHistList = (e) => {
+    axios.delete(`http://localhost:3001/history/donations?itemId=${id}`)
+    .then(res => {
+      setHistList(false)
+    })
+    .catch(err => {
+      console.log('delist err', err)
+    })
   }
 
   const handleClaimClick = () => {
@@ -84,8 +95,13 @@ const ItemView = ({ data, currentPage, revoke }) => {
           }
 
           {
-            revoke === 'Delist' &&
-            <Button variant="primary">Delist</Button>
+            (revoke === 'Delist' && histList) &&
+            <Button variant="primary" onClick={handleHistList}>Delist</Button>
+          }
+
+          {
+            !histList &&
+            <Button variant="secondary" disabled>Delist</Button>
           }
 
           <Card.Text>

--- a/components/ItemView.js
+++ b/components/ItemView.js
@@ -16,7 +16,18 @@ const ItemView = ({ data, currentPage, revoke }) => {
   const showMessage = () => setMessage(true);
   const closeMessage = () => setMessage(false);
   const [isClaim, setIsClaim] = useState(false);
+  const [histClaim, setHistClaim] = useState(true);
   const [page, setPage] = useState(currentPage);
+
+  const handleHistClaim = (e) => {
+    axios.put(`http://localhost:3001/history/claims?itemId=${id}`)
+        .then(res => {
+          setHistClaim(false);
+        })
+        .catch(err => {
+          console.log('unclaim err', err)
+        })
+  }
 
   const handleClaimClick = () => {
     axios.post('http://localhost:3001/claim', {
@@ -61,8 +72,15 @@ const ItemView = ({ data, currentPage, revoke }) => {
           }
 
           {
-            revoke === 'Unclaim' &&
-            <Button variant="primary">Unclaim</Button>
+            (revoke === 'Unclaim' && histClaim) &&
+            <Button variant="primary" onClick={handleHistClaim}>Unclaim</Button>
+          }
+
+          {
+            !histClaim &&
+            <Button variant="secondary" disabled>
+              Unclaim
+            </Button>
           }
 
           {


### PR DESCRIPTION
## What this PR does?

1. User can unclaim/delist an item when browsing claims/donations history. Clicking unclaim/delist will send PUT/DELETE request to server to delete/update relative records. Button will be disabled after click. When modal is closed, history list will be updated and won't show the unclaimed/delisted item any more.
2. Fixed small bug for the search bar

### After

![test_gif](http://g.recordit.co/mzHMw7PPZI.gif)

## Mentions

@ajpsyk @Doomslair @vinhle000 @davidhannn @stevenxm-chen @DevonL1010 @merosenlund 
Thank you!
