### PR TITLE
BugFix: Maps filter list, with  InfoWindow remaining. Also, added Address info to Item View

### DIFF
--- a/components/ItemView.js
+++ b/components/ItemView.js
@@ -1,7 +1,7 @@
 import { Button, Card, CloseButton, Modal } from 'react-bootstrap';
 import MessageView from './MessageView.js';
 import 'bootstrap/dist/css/bootstrap.min.css'
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import axios from 'axios';
 import ChatContext from '../context/chat/ChatContext';
 import AuthContext from '../context/auth/AuthContext';
@@ -19,6 +19,7 @@ const ItemView = ({ data, currentPage, revoke }) => {
   const [histClaim, setHistClaim] = useState(true);
   const [histList, setHistList] = useState(true);
   const [page, setPage] = useState(currentPage);
+  const [address, setAddress] = useState('')
 
   const handleHistClaim = (e) => {
     axios.put(`http://localhost:3001/history/claims?itemId=${id}`)
@@ -61,6 +62,27 @@ const ItemView = ({ data, currentPage, revoke }) => {
       socket.emit("join_chat", conversationId)
     }
 
+
+  /*
+  Converts location coordinates to Human Readable address string
+  Results may include a Google 'Plus Code' due to the mock data point
+  locations of items being in places that have no proper address.
+  */
+   useEffect( () => {
+    const geocoder = new google.maps.Geocoder();
+
+    geocoder.geocode({location: {
+      lat: data.latitude,
+      lng: data.longitude
+    }})
+    .then( response => {
+      console.log(response)
+      if (response.results[1]) {
+       setAddress(response.results[1].formatted_address)
+      }
+    })}, [data])
+
+
   return (
     <>
       <Card style={{ width: '24.9rem' }}>
@@ -68,7 +90,7 @@ const ItemView = ({ data, currentPage, revoke }) => {
         <Card.Body>
           <Card.Title>{name}</Card.Title>
           <Card.Text>Value</Card.Text>
-          <Card.Text>Location</Card.Text>
+          <Card.Text>{address}</Card.Text>
 
           {
             page !== 'history' &&

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -1,28 +1,14 @@
-import React, {useState} from 'react'
+import {useState, useEffect} from 'react'
 import { GoogleMap, Marker, InfoWindow} from '@react-google-maps/api';
 import {Card, Container, Row, Col, Modal} from 'react-bootstrap';
 import ItemView from './ItemView.js'
-
-//TODO: Remove after real/formatted data is provided
-//SampleTest data for showing markers
-// const items = [
-//   {
-//     name: 'Space Needle',
-//     img: 'https://cdn.pixabay.com/photo/2016/11/23/01/18/red-panda-1851661_1280.jpg',
-//     coordinates: { lat: 47.6205, lng: -122.3493 },
-//   },
-//   {
-//     name: "Cal Anderson Park",
-//     img: 'https://cdn.pixabay.com/photo/2016/11/23/01/15/red-panda-1851650_1280.jpg',
-//     coordinates: { lat: 47.6173, lng: -122.3195 },
-//   },
-// ]
 
 
 function MapView({viewableItems, currentLocation}) {
   const [selectedMarker, setSelectedMarker] = useState(null);
   const [isSelected, setIsSelected] = useState(false);
-  const [markers, setMarkers] = useState({})
+  const [markers, setMarkers] = useState({}) //objects to interact with GoogleMaps API
+
 
   const viewItem = () => setIsSelected(true);
   const closeItem = () => setIsSelected(false);
@@ -53,6 +39,12 @@ function MapView({viewableItems, currentLocation}) {
     markers[index].setLabel({color: 'white', text: (index + 1).toString()})
   }
 
+  useEffect( () => {
+    setSelectedMarker(null)
+    }, [viewableItems]
+  )
+
+
   return (
     <>
       <GoogleMap
@@ -66,7 +58,6 @@ function MapView({viewableItems, currentLocation}) {
         onClick={(e) => {
           setSelectedMarker(null)}}
       >
-        { /* Child components, such as markers, info windows, etc. */ }
 
         {viewableItems.map( (item, index) => {
           return (
@@ -90,7 +81,6 @@ function MapView({viewableItems, currentLocation}) {
           <InfoWindow
             options={{pixelOffset: new window.google.maps.Size(0, -45)}}
             position={{lat: selectedMarker.latitude, lng: selectedMarker.longitude}}
-
           >
 
             <div style={infoWindowStyle} onClick={() => setIsSelected(true)} >


### PR DESCRIPTION


## Story / Task
https://trello.com/c/GWeOg0Rr

https://trello.com/c/YWlczsCJ

## What this PR does?
- Fixed bug where the Infowindow for an older map Marker would remain after filtering the item list with the categories.
- Added address location to Item view using Google geocoder API


##After 

### BugFix Map infoWinow dispmissed

![BUGFix_infowindow](https://user-images.githubusercontent.com/26887964/146461773-bd544e7d-0efd-4291-8438-250ba27dba10.png)

### Address displayed for Item views
![Display Location of Item in modal](https://user-images.githubusercontent.com/26887964/146461777-9f821aec-8f07-4f83-92b8-423cdf5c77ae.gif)


### How to test / reproduce

- Here goes the steps to do the test.
- Other step.

### TODOs
- [ ] Tests
- [ ] Documentation

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Mentions
@ajpsyk @Doomslair @davidhannn
@stevenxm-chen @merosenlund
 @yxxy666 @DevonL1010 
Please have a look when you have a chance, thanks!